### PR TITLE
Make exchange rate resource use the service and forbid create duplicated exchange rates

### DIFF
--- a/src/main/java/com/uniara/rest/exceptions/AlreadyExistsException.java
+++ b/src/main/java/com/uniara/rest/exceptions/AlreadyExistsException.java
@@ -1,0 +1,11 @@
+package com.uniara.rest.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Created by carlos.ribeiro on 5/22/17.
+ */
+@ResponseStatus(value= HttpStatus.CONFLICT,reason="Essa cotação já está cadastrada no sistema")
+public class AlreadyExistsException extends Exception{
+}

--- a/src/main/java/com/uniara/rest/repository/ExchangeRateRepository.java
+++ b/src/main/java/com/uniara/rest/repository/ExchangeRateRepository.java
@@ -29,6 +29,9 @@ public class ExchangeRateRepository {
 
     public ExchangeRate findBySymbol(final String symbol) {
         final ExchangeRate exchangeRate = new ExchangeRate(symbol);
+        if (!this.exchangeRateList.contains(exchangeRate)) {
+            return null;
+        }
         return this.exchangeRateList.get(this.exchangeRateList.indexOf(exchangeRate));
     }
 }

--- a/src/main/java/com/uniara/rest/resource/ExchangeRateResource.java
+++ b/src/main/java/com/uniara/rest/resource/ExchangeRateResource.java
@@ -1,7 +1,9 @@
 package com.uniara.rest.resource;
 
 import com.uniara.rest.domain.ExchangeRate;
+import com.uniara.rest.exceptions.AlreadyExistsException;
 import com.uniara.rest.repository.ExchangeRateRepository;
+import com.uniara.rest.service.ExchangeRateService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,26 +17,21 @@ import java.util.List;
 @RequestMapping("/exchangerate")
 public class ExchangeRateResource {
 
-
     @Autowired
-    private ExchangeRateRepository exchangeRateRepository;
+    private ExchangeRateService exchangeRateService;
 
     @PostMapping(consumes = "application/json")
-    public void add(@RequestBody final ExchangeRate exchangeRate) {
-        this.exchangeRateRepository.save(exchangeRate);
+    public void add(@RequestBody final ExchangeRate exchangeRate) throws AlreadyExistsException {
+        this.exchangeRateService.create(exchangeRate);
     }
 
     @GetMapping
-    public List<ExchangeRate> list() {
-        return this.exchangeRateRepository.findAll();
-    }
+    public List<ExchangeRate> list() { return this.exchangeRateService.findAll(); }
 
     @GetMapping("/{symbol}")
-    public ExchangeRate show(@PathVariable final String symbol) { return this.exchangeRateRepository.findBySymbol(symbol); }
+    public ExchangeRate show(@PathVariable final String symbol) { return this.exchangeRateService.findBySymbol(symbol); }
 
     @DeleteMapping("/{symbol}")
-    public void delete(@PathVariable final String symbol) {
-        this.exchangeRateRepository.deleteBySymbol(symbol);
-    }
+    public void delete(@PathVariable final String symbol) { this.exchangeRateService.deleteBySymbol(symbol); }
 
 }

--- a/src/main/java/com/uniara/rest/service/ExchangeRateService.java
+++ b/src/main/java/com/uniara/rest/service/ExchangeRateService.java
@@ -1,0 +1,38 @@
+package com.uniara.rest.service;
+
+import com.uniara.rest.domain.ExchangeRate;
+import com.uniara.rest.exceptions.AlreadyExistsException;
+import com.uniara.rest.repository.ExchangeRateRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Created by carlos.ribeiro on 5/22/17.
+ */
+
+@Service
+public class ExchangeRateService {
+    @Autowired
+    private ExchangeRateRepository exchangeRateRepository;
+
+    public void create(final ExchangeRate exchangeRate) throws AlreadyExistsException {
+        if(findBySymbol(exchangeRate.getSymbol()) != null) {
+            throw new AlreadyExistsException();
+        }
+        exchangeRateRepository.save(exchangeRate);
+    }
+
+    public List<ExchangeRate> findAll() {
+        return exchangeRateRepository.findAll();
+    }
+
+    public ExchangeRate findBySymbol(final String symbol) {
+        return this.exchangeRateRepository.findBySymbol(symbol);
+    }
+
+    public boolean deleteBySymbol(final String symbol) {
+        return this.exchangeRateRepository.deleteBySymbol(symbol);
+    }
+}


### PR DESCRIPTION
 - Create a service to handle with exchange rates
 - Make the exchange rate resource uses the service instead the
 repository directly
 - Don't allow to register duplicated exchange rate (returns a 409
 instead)