### PR TITLE
Check if exchange rate exists on all endpoints

### DIFF
--- a/src/main/java/com/uniara/rest/exceptions/NotFoundException.java
+++ b/src/main/java/com/uniara/rest/exceptions/NotFoundException.java
@@ -6,6 +6,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * Created by carlos.ribeiro on 5/22/17.
  */
-@ResponseStatus(value=HttpStatus.CONFLICT,reason="Essa cotação já está cadastrada no sistema")
-public class AlreadyExistsException extends Exception{
+@ResponseStatus(value=HttpStatus.NOT_FOUND,reason="Cotação não encontrada")
+public class NotFoundException extends Exception{
 }

--- a/src/main/java/com/uniara/rest/repository/ExchangeRateRepository.java
+++ b/src/main/java/com/uniara/rest/repository/ExchangeRateRepository.java
@@ -35,4 +35,9 @@ public class ExchangeRateRepository {
         }
         return this.exchangeRateList.get(this.exchangeRateList.indexOf(exchangeRate));
     }
+
+    public boolean exists(final String symbol) {
+        final ExchangeRate exchangeRate = new ExchangeRate(symbol);
+        return this.exchangeRateList.contains(exchangeRate);
+    }
 }

--- a/src/main/java/com/uniara/rest/resource/ExchangeRateResource.java
+++ b/src/main/java/com/uniara/rest/resource/ExchangeRateResource.java
@@ -2,6 +2,7 @@ package com.uniara.rest.resource;
 
 import com.uniara.rest.domain.ExchangeRate;
 import com.uniara.rest.exceptions.AlreadyExistsException;
+import com.uniara.rest.exceptions.NotFoundException;
 import com.uniara.rest.repository.ExchangeRateRepository;
 import com.uniara.rest.service.ExchangeRateService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,9 +35,9 @@ public class ExchangeRateResource {
     public List<ExchangeRate> list() { return this.exchangeRateService.findAll(); }
 
     @GetMapping("/{symbol}")
-    public ExchangeRate show(@PathVariable final String symbol) { return this.exchangeRateService.findBySymbol(symbol); }
+    public ExchangeRate show(@PathVariable final String symbol) throws NotFoundException { return this.exchangeRateService.findBySymbol(symbol); }
 
     @DeleteMapping("/{symbol}")
-    public void delete(@PathVariable final String symbol) { this.exchangeRateService.deleteBySymbol(symbol); }
+    public void delete(@PathVariable final String symbol) throws NotFoundException { this.exchangeRateService.deleteBySymbol(symbol); }
 
 }

--- a/src/main/java/com/uniara/rest/service/ExchangeRateService.java
+++ b/src/main/java/com/uniara/rest/service/ExchangeRateService.java
@@ -2,6 +2,7 @@ package com.uniara.rest.service;
 
 import com.uniara.rest.domain.ExchangeRate;
 import com.uniara.rest.exceptions.AlreadyExistsException;
+import com.uniara.rest.exceptions.NotFoundException;
 import com.uniara.rest.repository.ExchangeRateRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -18,8 +19,8 @@ public class ExchangeRateService {
     private ExchangeRateRepository exchangeRateRepository;
 
     public void create(final ExchangeRate exchangeRate) throws AlreadyExistsException {
-        if(findBySymbol(exchangeRate.getSymbol()) != null) {
-            throw new AlreadyExistsException();
+        if(this.exchangeRateRepository.exists(exchangeRate.getSymbol())) {
+           throw new AlreadyExistsException();
         }
         exchangeRateRepository.save(exchangeRate);
     }
@@ -28,11 +29,17 @@ public class ExchangeRateService {
         return exchangeRateRepository.findAll();
     }
 
-    public ExchangeRate findBySymbol(final String symbol) {
+    public ExchangeRate findBySymbol(final String symbol) throws NotFoundException {
+        if(!this.exchangeRateRepository.exists(symbol)) {
+            throw new NotFoundException();
+        }
         return this.exchangeRateRepository.findBySymbol(symbol);
     }
 
-    public boolean deleteBySymbol(final String symbol) {
+    public boolean deleteBySymbol(final String symbol) throws NotFoundException {
+        if(!this.exchangeRateRepository.exists(symbol)) {
+            throw new NotFoundException();
+        }
         return this.exchangeRateRepository.deleteBySymbol(symbol);
     }
 }


### PR DESCRIPTION
Before create, delete and find the exchange, check if the specified
resource exists. If not, raise an error